### PR TITLE
Fixes pip3 dependeces error.

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,1 @@
-pyln.proto.message
+pyln.proto>=0.10.1


### PR DESCRIPTION
Just snooping around the spec world, I found the following missing inside the pip install process.

I was unable to pull the dependencies in a new env.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>