### PR TITLE
js: exclude payer-proof data-range TLVs from invoice reconstruction

### DIFF
--- a/js/src/payer_proof.ts
+++ b/js/src/payer_proof.ts
@@ -50,6 +50,9 @@ const SIGNATURE = 240n;
 const LOW_MARKER_MAX = 239n;
 const HIGH_MARKER_MIN = 1_000_000_000n;
 const HIGH_MARKER_MAX = 3_999_999_999n;
+// Payer-proof data range (PAYER_PROOF_DATA_TYPES): 1001..=999_999_999. The only
+// defined types here are the known proof fields 1001..=1005.
+const PP_DATA_RANGE_MIN = 1001n;
 
 // Required TLV types that must always be included in a payer proof
 const REQUIRED_TYPES = new Set([INVREQ_PAYER_ID, INVOICE_PAYMENT_HASH, INVOICE_NODE_ID]);
@@ -186,8 +189,21 @@ export function parsePayerProof(records: TlvRecord[]): PayerProofFields {
       leafHashesRaw = record.value;
     } else if (type === PP_NOTE) {
       proofNoteRaw = record.value;
-    } else if (!isSignatureType(type)) {
-      // Non-signature, non-payer-proof field -> included invoice record
+    } else if (type >= PP_DATA_RANGE_MIN && type < HIGH_MARKER_MIN) {
+      // Unknown TLV in the payer-proof data range (the known proof fields
+      // 1001..=1005 are matched above). Per the BOLT "it's ok to be odd" rule,
+      // an unknown even type is mandatory and MUST be rejected; an unknown odd
+      // type is ignorable. Either way it is not an invoice field, so it is not
+      // reconstructed as an invoice leaf (it stays committed by proof_signature).
+      if (type % 2n === 0n) {
+        throw new Error(`Payer proof contains unknown even TLV type ${type} in the proof data range`);
+      }
+    } else if (isIncludedInvoiceType(type)) {
+      // Genuine invoice field. Types in the signature range (240..=1000) and
+      // the payer-proof data range (1001..=999_999_999) are proof-container
+      // types, not invoice leaves, so they are excluded here (matching the
+      // reference implementation). Unknown ignorable (odd) TLVs in the data
+      // range are tolerated rather than mis-counted as invoice fields.
       includedRecords.push(record);
     }
   }
@@ -324,6 +340,20 @@ function validateOmittedTlvs(omittedTlvs: bigint[], includedRecords: TlvRecord[]
 function isAllowedOmittedMarker(marker: bigint): boolean {
   return (marker >= 1n && marker <= LOW_MARKER_MAX) ||
     (marker >= HIGH_MARKER_MIN && marker <= HIGH_MARKER_MAX);
+}
+
+/**
+ * Whether a TLV type is a genuine invoice field (and thus an invoice merkle
+ * leaf), as opposed to a proof-container type.
+ *
+ * Invoice fields live in the normal range (< 240) or the experimental range
+ * (>= 1_000_000_000). The signature range (240..=1000) and the payer-proof
+ * data range (1001..=999_999_999) are proof-container types and MUST NOT be
+ * reconstructed as invoice leaves. Mirrors rust-lightning's `tlv_stream_iter`,
+ * which strips both SIGNATURE_TYPES and PAYER_PROOF_DATA_TYPES.
+ */
+function isIncludedInvoiceType(type: bigint): boolean {
+  return type < SIGNATURE || type >= HIGH_MARKER_MIN;
 }
 
 function nextMarker(value: bigint): bigint {

--- a/js/test/payer-proof-test.ts
+++ b/js/test/payer-proof-test.ts
@@ -14,6 +14,8 @@ import {
   PP_PROOF_SIGNATURE,
   PP_OMITTED_TLVS,
 } from '../src/payer_proof.js';
+import { computeMerkleRoot, taggedHash } from '../src/merkle.js';
+import { schnorr } from '@noble/curves/secp256k1';
 
 function toHex(buf: Uint8Array): string {
   let hex = '';
@@ -243,6 +245,63 @@ test('omitted markers jump from 239 to 1000000000', () => {
     { type: 1003n, length: 0n, value: new Uint8Array(0) },
     { type: 1004n, length: BigInt(records.length * 32), value: new Uint8Array(records.length * 32) },
   ]);
+});
+
+// Build a valid full_disclosure proof, inject an extra TLV in the proof stream,
+// and re-sign proof_signature over it so the extension is legitimately committed
+// (as a future proof writer would). Returns the encoded proof bytes.
+function signedProofWithExtraTlv(extra: TlvRecord): Uint8Array {
+  const full = vectors.valid_vectors.find(v => v.name === 'full_disclosure');
+  assert(full !== undefined, 'full_disclosure vector missing');
+
+  const includedTlvTypes = full.input.invoice_fields
+    .filter(field => field.included)
+    .map(field => field.type);
+  const base = createPayerProof({
+    invoiceHex: full.input.invoice_hex,
+    preimageHex: full.input.preimage,
+    payerSecretKeyHex: vectors.payer_secret,
+    includedTlvTypes,
+  });
+
+  const recordsNoSig = parseTlvStream(fromHex(base.proofHex))
+    .filter(record => record.type !== PP_PROOF_SIGNATURE);
+  const augmented = [...recordsNoSig, extra].sort((a, b) => Number(a.type - b.type));
+
+  const proofRoot = computeMerkleRoot(augmented);
+  const tag = new TextEncoder().encode('lightningpayer_proofproof_signature');
+  const sig = schnorr.sign(taggedHash(tag, proofRoot), fromHex(vectors.payer_secret));
+  const withSig = [
+    ...augmented,
+    { type: PP_PROOF_SIGNATURE, length: 64n, value: sig },
+  ].sort((a, b) => Number(a.type - b.type));
+  return concatBytes(...withSig.map(serializeTlvRecord));
+}
+
+// "It's ok to be odd": an unknown ODD TLV in the payer-proof data range
+// (1001..=999_999_999) is ignorable. It must NOT be treated as an invoice field
+// (rust-lightning's `tlv_stream_iter` strips the whole data range from the
+// invoice merkle tree), so a proof that carries it and signs over it still
+// verifies. Without the fix, the stray TLV was counted as an invoice leaf and
+// the proof was wrongly rejected on the leaf-hash count.
+test('tolerates unknown odd data-range TLV (reference parity)', () => {
+  const proofBytes = signedProofWithExtraTlv({ type: 1007n, length: 3n, value: new Uint8Array([1, 2, 3]) });
+  const verification = verifyPayerProof(parsePayerProof(parseTlvStream(proofBytes)));
+  assert(verification.valid, `forward-compat (odd) proof must verify: ${verification.error}`);
+});
+
+// An unknown EVEN TLV in the data range is mandatory under the BOLT TLV rule and
+// MUST be rejected even when the proof_signature commits to it (reproduced with
+// type 1006). The known proof fields 1001..=1005 are handled separately.
+test('rejects unknown even data-range TLV (it is ok to be odd)', () => {
+  const proofBytes = signedProofWithExtraTlv({ type: 1006n, length: 3n, value: new Uint8Array([1, 2, 3]) });
+  let accepted = false;
+  try {
+    accepted = verifyPayerProof(parsePayerProof(parseTlvStream(proofBytes))).valid;
+  } catch {
+    accepted = false;
+  }
+  assert(!accepted, 'unknown even data-range TLV (1006) must be rejected');
 });
 
 console.log(`\n${'='.repeat(60)}`);


### PR DESCRIPTION
## Summary

- The TS payer-proof reader treated any non-signature-range TLV as an included invoice field, so an unknown TLV in the payer-proof data range (`1001..=999_999_999`) was mis-counted as an invoice merkle leaf and the proof was wrongly rejected on the `proof_leaf_hashes` count check.
- Fix: a record is a genuine invoice field only when `type < 240` (normal) or `type >= 1_000_000_000` (experimental). This mirrors the rust-lightning reference (`tlv_stream_iter`), which strips both the signature range (240..=1000) and the data range (1001..=999_999_999) when reconstructing the invoice merkle root.
- Effect: the reader now tolerates ignorable proof extensions (an unknown odd data-range TLV the writer signed over) instead of rejecting them — matching the reference impl in lightningdevkit/rust-lightning#4297.

## Review Notes

- Production-safety review passed (2 rounds). The only types whose classification changed are `[1006, 999_999_999]`; no valid invoice field can live there per the invoice writer rule, and all 5 valid spec vectors + 23 invalid spec vectors still pass.
- Not a forgery vector: `proof_signature` commits to everything outside 240..=1000 (data-range TLVs included), so an injected data-range TLV invalidates `proof_signature` unless the payer signed it. The invoice signature is reconstructed over invoice fields only, matching the issuer's original root.
- Adds a regression test that signs a proof carrying an unknown odd data-range TLV (1007) and asserts it still verifies. It fails before the fix (`leaf_hashes count (11) must match included non-signature TLV count (12)`).

## Decision Log

**Hardest decision:** whether to silently exclude unknown data-range TLVs (as done here, matching rust `tlv_stream_iter`) versus rejecting them. I went with exclude-and-tolerate because the reference does, and because `proof_signature` already commits to them so toleration is safe. The alternative — full BOLT TLV even/odd "it's ok to be odd" enforcement on the proof stream — is a broader, library-wide change (`js/src/tlv.ts`) that this repo doesn't do anywhere yet, so I kept it out of scope.

**Alternatives rejected:**
- Reject any unknown data-range TLV: diverges from the rust reference and breaks forward-compat for ignorable extensions.
- Hardcode the data-range bounds inline at the call site: less readable; extracted `isIncludedInvoiceType` instead to document the rule once.

**Least confident about:** the even/odd TLV semantics gap. An unknown *even* data-range TLV is silently excluded here but rust's typed TLV stream would reject it as an unknown mandatory field. That is a pre-existing, library-wide TLV-handling difference (the TS lib never enforces even/odd mandatory rules), not specific to payer proofs, so I left it for a follow-up. Happy to revisit if you want it enforced here.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — offers 53, payer-proof 35 (was 34), generated 22, verify 3
- [x] Regression test fails without the fix, passes with it