### PR TITLE
js: release bolt12-utils v0.1.2

### DIFF
--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `bolt12-utils` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2026-06-26
+
+### Fixed
+
+- Payer proof reader: exclude the payer-proof data range (`1001..=999_999_999`)
+  from invoice merkle reconstruction. An unknown TLV in that range was being
+  mis-counted as an invoice leaf, which wrongly rejected the proof on the
+  `proof_leaf_hashes` count. A record is now treated as an invoice field only
+  when its type is `< 240` (normal) or `>= 1_000_000_000` (experimental),
+  mirroring the rust-lightning reference (`tlv_stream_iter`).
+- Payer proof reader: reject unknown **even** TLVs in the payer-proof data range
+  per the BOLT "it's ok to be odd" rule; unknown **odd** types remain ignorable
+  and stay committed by `proof_signature`.
+
+## [0.1.1]
+
+- Initial published release: BOLT 12 offer / invoice / payer-proof decoding,
+  validation, signing, and verification utilities.

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bolt12-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bolt12-utils",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.8.1",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bolt12-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pure JS/TS BOLT12 utilities for Lightning Network — decode, validate, sign, and verify offers, invoices, and payer proofs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump `bolt12-utils` `0.1.1` -> `0.1.2` (`js/package.json`, `js/package-lock.json`).
- Add `js/CHANGELOG.md` (Keep a Changelog format).

This is a release-metadata PR for the payer-proof data-range fix that landed in #33. No code changes beyond the version bump and changelog.

## Changelog (0.1.2)

Fixed:
- Payer proof reader excludes the payer-proof data range (`1001..=999_999_999`) from invoice merkle reconstruction, so an unknown TLV there is no longer mis-counted as an invoice leaf (which wrongly failed the `proof_leaf_hashes` count). A record is an invoice field only when `type < 240` or `type >= 1_000_000_000`, mirroring rust-lightning's `tlv_stream_iter`.
- Reject unknown even TLVs in the data range per the BOLT "it's ok to be odd" rule; unknown odd types remain ignorable and stay committed by `proof_signature`.

## Notes

- `dist/` is gitignored; `npm publish` regenerates it via `prepublishOnly`. The actual npm publish will be done after this merges.
- No tag created here — leaving the `v0.1.2` tag / npm publish to the release step.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 53 + 36 + 22 + 3 all pass
- [x] `npm pack --dry-run` -> `bolt12-utils@0.1.2`, 52 files, 57.6 kB